### PR TITLE
Add gcloud support

### DIFF
--- a/credentials.go
+++ b/credentials.go
@@ -92,7 +92,7 @@ type GCPProviderConfig struct {
 func (gpc *GCPProviderConfig) CredentialsPath() string {
 	// https://github.com/googleapis/google-cloud-go/blob/master/compute/metadata/metadata.go#L299
 	// https://github.com/golang/oauth2/blob/master/google/google.go#L175
-	return "/computeMetadata/v1/instance/service-accounts/default/token"
+	return "/computeMetadata/v1/instance/service-accounts/{service_account}/token"
 }
 
 func (gpc *GCPProviderConfig) GetCredentials(client *vault.Client) (interface{}, time.Duration, error) {

--- a/example/gcp-probe.yaml
+++ b/example/gcp-probe.yaml
@@ -1,25 +1,25 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: aws-probe
+  name: gcp-probe
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: aws-probe
+  name: gcp-probe
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: aws-probe
+      app: gcp-probe
   template:
     metadata:
       labels:
-        app: aws-probe
+        app: gcp-probe
     spec:
-      serviceAccountName: aws-probe
+      serviceAccountName: gcp-probe
       containers:
-        - name: aws-credentials
+        - name: gcp-credentials
           image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.2.1
           env:
             - name: VAULT_ADDR
@@ -34,28 +34,30 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            # This value corresponds to the this variable:
+            # https://github.com/utilitywarehouse/tf_kube_creds_provider_via_vault/blob/master/gcp/variables.tf#L1-L3
+            - name: ENVIRONMENT
+              value: exp-1
             - name: VKAC_KUBE_AUTH_ROLE
-              value: "$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)"
-            - name: VKAC_AWS_SECRET_ROLE
-              value: "$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)"
+              value: "$(ENVIRONMENT)-$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)"
+            - name: VKAC_GCP_SECRET_ROLESET
+              value: "$(ENVIRONMENT)-$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)"
           volumeMounts:
             - name: vault-tls
               mountPath: /etc/tls
-        - name: aws-probe
-          image: mesosphere/aws-cli
+        - name: gcp-probe
+          image: google/cloud-sdk:alpine
           command:
-            - ash
+            - sh
             - -c
             - |
               while true; do
-                aws sts get-caller-identity
+                gcloud dns managed-zones list
                 sleep 600
               done
           env:
-            - name: AWS_CONTAINER_CREDENTIALS_FULL_URI
-              value: "http://127.0.0.1:8000/credentials"
-            - name: AWS_REGION
-              value: "eu-west-1"
+            - name: GCE_METADATA_HOST
+              value: "127.0.0.1:8000"
       volumes:
         - name: vault-tls
           configMap:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/golang/protobuf v1.4.1 // indirect
+	github.com/gorilla/mux v1.7.4
 	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/hashicorp/go-retryablehttp v0.6.6 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/gorilla/mux v1.7.4 h1:VuZ8uybHlWmqV03+zRzdwKL4tUnIp1MAQtp1mIFE1bc=
+github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=

--- a/main.go
+++ b/main.go
@@ -95,10 +95,10 @@ func main() {
 
 	// Serve the credentials
 	webserver := &Webserver{
-		Credentials:     creds,
-		CredentialsPath: providerConfig.CredentialsPath(),
-		Errors:          errors,
-		ListenAddress:   listenAddress,
+		Credentials:    creds,
+		ProviderConfig: providerConfig,
+		Errors:         errors,
+		ListenAddress:  listenAddress,
 	}
 
 	go credentialsRenewer.Start()

--- a/main.go
+++ b/main.go
@@ -71,11 +71,13 @@ func main() {
 			AwsPath: awsPath,
 			AwsRole: awsRole,
 		}
+		log.Printf("using AWS secrets engine")
 	} else if len(gcpRoleSet) > 0 {
 		providerConfig = &GCPProviderConfig{
 			GcpPath:    gcpPath,
 			GcpRoleSet: gcpRoleSet,
 		}
+		log.Printf("using GCP secrets engine")
 	} else {
 		log.Fatalf("could not determine cloud provider")
 	}

--- a/webserver.go
+++ b/webserver.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/gorilla/mux"
 	"github.com/utilitywarehouse/go-operational/op"
 )
 
@@ -41,15 +42,17 @@ func (w *Webserver) Start() {
 		}
 	}()
 
+	r := mux.NewRouter()
+
 	// Add operational endpoints
-	http.Handle("/__/", op.NewHandler(op.NewStatus(appName, appDescription).
+	r.Handle("/__/", op.NewHandler(op.NewStatus(appName, appDescription).
 		AddOwner("system", "#infra").
 		AddLink("readme", fmt.Sprintf("https://github.com/utilitywarehouse/%s/blob/master/README.md", appName)).
 		ReadyAlways()),
 	)
 
 	// Serve credentials at the appropriate path for the provider
-	http.HandleFunc(w.CredentialsPath, func(w http.ResponseWriter, r *http.Request) {
+	r.HandleFunc(w.CredentialsPath, func(w http.ResponseWriter, r *http.Request) {
 		lock.RLock()
 		defer lock.RUnlock()
 		enc := json.NewEncoder(w)
@@ -57,5 +60,5 @@ func (w *Webserver) Start() {
 	})
 
 	log.Printf("Listening on %s", w.ListenAddress)
-	w.Errors <- http.ListenAndServe(w.ListenAddress, nil)
+	w.Errors <- http.ListenAndServe(w.ListenAddress, r)
 }


### PR DESCRIPTION
By introducing additonal endpoints per-provider, we can support the extra metadata request that `gcloud` (and potentially other tooling) requires before it can request a token.