### PR TITLE
Assume a specific role

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ updated and valid.
 Refer to the [example](example/) for a reference Kubernetes deployment.
 
 Supported providers (secret engines):
+
 - `aws`
 - `gcp`
 
@@ -37,6 +38,9 @@ credentials which are served over http.
 Optional:
 
 - `VKAC_AWS_SECRET_BACKEND_PATH`: path of the aws secret backend (default: `aws`)
+- `VKAC_AWS_SECRET_ROLE_ARN`: the ARN of the role to assume. This is required
+  when there is more than one `role_arn` configured against the backend role
+  (not set by default)
 - `VKAC_GCP_SECRET_BACKEND_PATH`: path of the gcp secret backend (default: `gcp`)
 - `VKAC_KUBE_AUTH_BACKEND_PATH`: path of the kubernetes auth backend (default: `kubernetes`)
 - `VKAC_KUBE_SA_TOKEN_PATH`: path to a file containing the Kubernetes service account token (default: `/var/run/secrets/kubernetes.io/serviceaccount/token`)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	awsPath    = os.Getenv("VKAC_AWS_SECRET_BACKEND_PATH")
+	awsRoleArn = os.Getenv("VKAC_AWS_SECRET_ROLE_ARN")
 	awsRole    = os.Getenv("VKAC_AWS_SECRET_ROLE")
 	gcpPath    = os.Getenv("VKAC_GCP_SECRET_BACKEND_PATH")
 	gcpRoleSet = os.Getenv("VKAC_GCP_SECRET_ROLESET")
@@ -68,8 +69,9 @@ func main() {
 	var providerConfig ProviderConfig
 	if len(awsRole) > 0 {
 		providerConfig = &AWSProviderConfig{
-			AwsPath: awsPath,
-			AwsRole: awsRole,
+			AwsPath:    awsPath,
+			AwsRoleArn: awsRoleArn,
+			AwsRole:    awsRole,
 		}
 		log.Printf("using AWS secrets engine")
 	} else if len(gcpRoleSet) > 0 {


### PR DESCRIPTION
An AWS secret role in Vault can have multiple role arns associated with it. In that case you need to provide the name of the role you want to assume when you read the data from vault.