### PR TITLE
operator: restrict role creation based on rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It's comprised of two parts:
 
 Refer to the [example](manifests/operator/) for a reference Kubernetes deployment.
 
-Annotate your serviceaccounts and the operator will create the corresponding
+Annotate your service accounts and the operator will create the corresponding
 login role and aws secret role in Vault at
 `auth/kubernetes/roles/<prefix>_aws_<namespace>_<name>` and
 `aws/role/<prefix>_aws_<namespace>_<name>` respectively, where `<prefix>` is the
@@ -34,8 +34,39 @@ kind: ServiceAccount
 metadata:
   name: foobar
   annotations:
-    uw.systems/aws-role: "<your role>"
+    uw.systems/aws-role: "arn:aws:iam::000000000000:role/some-role-name"
 ```
+
+### Config file
+
+You can control which service accounts can assume which roles based on their
+namespace by passing a yaml file to the operator with the flag `-config-file`.
+
+For example, the following configuration allows service accounts in `kube-system` 
+and namespaces prefixed with `system-` to assume roles under the `sysadmin/*` path,
+roles that begin with `sysadmin-` or a specific `org/s3-admin` role in the accounts
+`000000000000` and `111111111111`.
+
+```
+aws:
+  rules:
+    - namespacePatterns:
+        - kube-system
+        - system-*
+      roleNamePatterns:
+       - sysadmin-*
+       - sysadmin/*
+       - org/s3-admin
+      accountIDs:
+        - 000000000000
+        - 111111111111
+```
+
+If `accountIDs` is omitted or empty then any account is permitted. The other two
+parameters are required.
+
+The pattern matching supports [shell file name
+patterns](https://golang.org/pkg/path/filepath/#Match).
 
 ## Sidecars
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/utilitywarehouse/vault-kube-cloud-credentials
 go 1.14
 
 require (
+	github.com/aws/aws-sdk-go v1.30.27
 	github.com/gorilla/mux v1.7.4
 	github.com/hashicorp/vault v1.5.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.0
@@ -12,6 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.6.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/utilitywarehouse/go-operational v0.0.0-20190722153447-b0f3f6284543
+	gopkg.in/yaml.v2 v2.3.0
 	gotest.tools/v3 v3.0.2 // indirect
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	flagOperatorAWSBackend      = operatorCommand.String("aws-backend", "aws", "AWS secret backend path")
 	flagOperatorKubeAuthBackend = operatorCommand.String("kube-auth-backend", "kubernetes", "Kubernetes auth backend")
 	flagOperatorMetricsAddr     = operatorCommand.String("metrics-address", ":8080", "Metrics address")
+	flagOperatorConfigFile      = operatorCommand.String("config-file", "", "Path to a configuration file")
 
 	awsSidecarCommand    = flag.NewFlagSet("aws-sidecar", flag.ExitOnError)
 	flagAWSBackend       = awsSidecarCommand.String("backend", "aws", "AWS secret backend path")
@@ -109,6 +110,13 @@ func main() {
 		if err != nil {
 			log.Fatalf("error creating operator: %s", err)
 		}
+
+		if *flagOperatorConfigFile != "" {
+			if err := o.LoadConfig(*flagOperatorConfigFile); err != nil {
+				log.Fatalf("error loading configuration file: %s", err)
+			}
+		}
+
 		if err = o.SetupWithManager(mgr); err != nil {
 			log.Fatalf("error creating controller: %s", err)
 		}


### PR DESCRIPTION
Allow or disallow role_arns for namespaces based on a set of rules that ensure:
- The ARN is a valid ARN
- The account ID is permitted for the namespace
- The name of the role is permitted for the namespace