### PR TITLE
operator: fix panic when returned list is nil

### DIFF
--- a/operator/aws.go
+++ b/operator/aws.go
@@ -193,8 +193,8 @@ func (o *AWSOperator) Start(stop <-chan struct{}) error {
 		return err
 	}
 	if awsRoleList != nil {
-		if keys, ok := awsRoleList.Data["keys"]; ok {
-			err = o.garbageCollect(keys.([]interface{}))
+		if keys, ok := awsRoleList.Data["keys"].([]interface{}); ok {
+			err = o.garbageCollect(keys)
 			if err != nil {
 				return err
 			}
@@ -207,8 +207,8 @@ func (o *AWSOperator) Start(stop <-chan struct{}) error {
 		return err
 	}
 	if kubeAuthRoleList != nil {
-		if keys, ok := kubeAuthRoleList.Data["keys"]; ok {
-			err = o.garbageCollect(keys.([]interface{}))
+		if keys, ok := kubeAuthRoleList.Data["keys"].([]interface{}); ok {
+			err = o.garbageCollect(keys)
 			if err != nil {
 				return err
 			}
@@ -221,8 +221,8 @@ func (o *AWSOperator) Start(stop <-chan struct{}) error {
 		return err
 	}
 	if policies != nil {
-		if keys, ok := policies.Data["keys"]; ok {
-			err = o.garbageCollect(keys.([]interface{}))
+		if keys, ok := policies.Data["keys"].([]interface{}); ok {
+			err = o.garbageCollect(keys)
 			if err != nil {
 				return err
 			}

--- a/operator/aws.go
+++ b/operator/aws.go
@@ -192,9 +192,13 @@ func (o *AWSOperator) Start(stop <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	err = o.garbageCollect(awsRoleList.Data["keys"].([]interface{}))
-	if err != nil {
-		return err
+	if awsRoleList != nil {
+		if keys, ok := awsRoleList.Data["keys"]; ok {
+			err = o.garbageCollect(keys.([]interface{}))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// Kubernetes auth roles
@@ -202,9 +206,13 @@ func (o *AWSOperator) Start(stop <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	err = o.garbageCollect(kubeAuthRoleList.Data["keys"].([]interface{}))
-	if err != nil {
-		return err
+	if kubeAuthRoleList != nil {
+		if keys, ok := kubeAuthRoleList.Data["keys"]; ok {
+			err = o.garbageCollect(keys.([]interface{}))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// Policies
@@ -212,9 +220,13 @@ func (o *AWSOperator) Start(stop <-chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	err = o.garbageCollect(policies.Data["keys"].([]interface{}))
-	if err != nil {
-		return err
+	if policies != nil {
+		if keys, ok := policies.Data["keys"]; ok {
+			err = o.garbageCollect(keys.([]interface{}))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	log.Print("aws garbage collection finished")


### PR DESCRIPTION
The vault client returns a nil secret when listing a backend with no keys. This was causing a panic when garbage collecting on a vault server without any existing items.

I've fixed the bug and added a test which would have caught this issue.