### PR TITLE
add structured logging with zap

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/aws/aws-sdk-go v1.30.27
+	github.com/go-logr/logr v0.1.0
 	github.com/gorilla/mux v1.7.4
 	github.com/hashicorp/vault v1.5.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.0

--- a/operator/aws_test.go
+++ b/operator/aws_test.go
@@ -18,6 +18,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 // TestAWSOperatorReconcile walks through creating, updating and removing objects
@@ -40,6 +41,8 @@ func TestAWSOperatorReconcile(t *testing.T) {
 	fakeVaultCluster := newFakeVaultCluster(t)
 
 	core := fakeVaultCluster.Cores[0]
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	a, err := NewAWSOperator(&AWSOperatorConfig{
 		Config: &Config{
@@ -155,6 +158,8 @@ func TestOperatorReconcileDelete(t *testing.T) {
 
 	core := fakeVaultCluster.Cores[0]
 
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
 	a, err := NewAWSOperator(&AWSOperatorConfig{
 		Config: &Config{
 			KubeClient:            fakeKubeClient,
@@ -244,6 +249,8 @@ func TestOperatorReconcileBlocked(t *testing.T) {
 	fakeVaultCluster := newFakeVaultCluster(t)
 
 	core := fakeVaultCluster.Cores[0]
+
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	a, err := NewAWSOperator(&AWSOperatorConfig{
 		Config: &Config{
@@ -433,7 +440,11 @@ func TestAWSOperatorStart(t *testing.T) {
 // TestAWSOperatorAdmitEvent tests that events are allowed and disallowed
 // according to the rules
 func TestAWSOperatorAdmitEvent(t *testing.T) {
-	o := &AWSOperator{}
+	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
+
+	o := &AWSOperator{
+		log: ctrl.Log.WithName("operator").WithName("aws"),
+	}
 
 	// Test that without any rules any valid event is admitted
 	assert.True(t, o.admitEvent("foobar", "arn:aws:iam::111111111111:role/foobar-role"))

--- a/operator/operator.go
+++ b/operator/operator.go
@@ -6,6 +6,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var (
+	log = ctrl.Log.WithName("operator")
+)
+
 // Config is the base configuration for an operator
 type Config struct {
 	KubeClient            client.Client

--- a/sidecar/credentials.go
+++ b/sidecar/credentials.go
@@ -2,7 +2,6 @@ package sidecar
 
 import (
 	"io/ioutil"
-	"log"
 	"math/rand"
 	"time"
 
@@ -45,7 +44,7 @@ func (cr *credentialsRenewer) start() {
 		creds, duration, err := cr.renew()
 		if err != nil {
 			d := b.Duration()
-			log.Printf("error: %s, backoff: %v", err, d)
+			log.Error(err, "error renewing credentials", "backoff", d)
 			time.Sleep(d)
 			continue
 		}

--- a/sidecar/provider_aws.go
+++ b/sidecar/provider_aws.go
@@ -6,7 +6,6 @@ import (
 	vault "github.com/hashicorp/vault/api"
 	"io"
 	"io/ioutil"
-	"log"
 	"time"
 )
 
@@ -62,7 +61,7 @@ func (apc *AWSProviderConfig) credentials(client *vault.Client) (interface{}, ti
 		return nil, -1, err
 	}
 
-	log.Printf("new aws credentials: %s, expiring %s", secret.Data["access_key"].(string), l.Data.ExpireTime.Format("2006-01-02 15:04:05"))
+	log.Info("new aws credentials", "access_key", secret.Data["access_key"].(string), "expiration", l.Data.ExpireTime.Format("2006-01-02 15:04:05"))
 
 	return &AWSCredentials{
 		AccessKeyID:     secret.Data["access_key"].(string),

--- a/sidecar/provider_gcp.go
+++ b/sidecar/provider_gcp.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"github.com/gorilla/mux"
 	vault "github.com/hashicorp/vault/api"
-	"log"
 	"net/http"
 	"time"
 )
@@ -51,7 +50,7 @@ func (gpc *GCPProviderConfig) credentials(client *vault.Client) (interface{}, ti
 	if err != nil {
 		return nil, -1, err
 	}
-	log.Printf("new gcp credentials, expiring %s", time.Unix(expiresAtSeconds, 0).Format("2006-01-02 15:04:05"))
+	log.Info("new gcp credentials", "expiration", time.Unix(expiresAtSeconds, 0).Format("2006-01-02 15:04:05"))
 
 	return &GCPCredentials{
 		AccessToken:  secret.Data["token"].(string),

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -2,6 +2,11 @@ package sidecar
 
 import (
 	vault "github.com/hashicorp/vault/api"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	log = ctrl.Log.WithName("sidecar").WithName("aws")
 )
 
 // Config configures the sidecar

--- a/sidecar/webserver.go
+++ b/sidecar/webserver.go
@@ -3,7 +3,6 @@ package sidecar
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 
@@ -36,7 +35,7 @@ func (w *webserver) start() {
 		for {
 			select {
 			case c := <-w.credentials:
-				log.Printf("webserver: received credentials")
+				log.Info("webserver recevied credentials")
 				latestCredentials = c
 			}
 		}
@@ -62,6 +61,6 @@ func (w *webserver) start() {
 
 	w.providerConfig.setupAdditionalEndpoints(r)
 
-	log.Printf("Listening on %s", w.listenAddress)
+	log.Info("webserver is listening", "address", w.listenAddress)
 	w.errors <- http.ListenAndServe(w.listenAddress, r)
 }


### PR DESCRIPTION
By default the controller-runtime manager logs with a null logger, so in order to capture log messages internal to the manager you need to set a go-logr compatible logger.

Zap is the common one suggested by controller-runtime, so I've gone with that.

I've amended the sidecars to use it as well as the operator for the sake of consistency.

```
{"level":"info","ts":1598428325.1022131,"logger":"operator.aws","msg":"Wrote kubernetes auth backend role","namespace":"kube-system","serviceaccount":"external-dns","key":"exp-1_aws_kube-system_external-dns"}
{"level":"info","ts":1598428325.381162,"logger":"operator.aws","msg":"Wrote aws secret backend role","namespace":"kube-system","serviceaccount":"external-dns","key":"exp-1_aws_kube-system_external-dns"}
{"level":"info","ts":1598428325.541685,"logger":"operator.aws","msg":"Wrote policy","namespace":"sys-auth","serviceaccount":"ssh-key-manager","key":"exp-1_aws_sys-auth_ssh-key-manager"}
{"level":"info","ts":1598428325.702722,"logger":"operator.aws","msg":"Wrote kubernetes auth backend role","namespace":"sys-auth","serviceaccount":"ssh-key-manager","key":"exp-1_aws_sys-auth_ssh-key-manager"}
{"level":"info","ts":1598428325.989653,"logger":"operator.aws","msg":"Wrote aws secret backend role","namespace":"sys-auth","serviceaccount":"ssh-key-manager","key":"exp-1_aws_sys-auth_ssh-key-manager"}
```

```
{"level":"error","ts":1598428192.432286,"logger":"sidecar.aws","msg":"error renewing credentials","backoff":2,"error":"Put \"https://localhost:8200/v1/auth/kubernetes/login\": dial tcp [::1]:8200: connect: connection refused","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/robertbest/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128\ngithub.com/utilitywarehouse/vault-kube-cloud-credentials/sidecar.(*credentialsRenewer).start\n\t/Users/robertbest/go/src/github.com/utilitywarehouse/vault-kube-cloud-credentials/sidecar/credentials.go:47"}
{"level":"error","ts":1598428197.6633909,"logger":"sidecar.aws","msg":"error renewing credentials","backoff":3.946705711,"error":"Put \"https://localhost:8200/v1/auth/kubernetes/login\": dial tcp [::1]:8200: connect: connection refused","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/Users/robertbest/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128\ngithub.com/utilitywarehouse/vault-kube-cloud-credentials/sidecar.(*credentialsRenewer).start\n\t/Users/robertbest/go/src/github.com/utilitywarehouse/vault-kube-cloud-credentials/sidecar/credentials.go:47"}
{"level":"info","ts":1598428203.003469,"logger":"sidecar.aws","msg":"new aws credentials","access_key":"ASIA52ODWF5UFQDNYVMD","expiration":"2020-08-26 08:05:02"}
{"level":"info","ts":1598428203.0045729,"logger":"sidecar.aws","msg":"webserver is listening","address":"127.0.0.1:8000"}
```