### PR TITLE
operator: use the same vault config with the client and the operator

### DIFF
--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 				KubernetesAuthBackend: *flagOperatorKubeAuthBackend,
 				Prefix:                *flagOperatorPrefix,
 				VaultClient:           vaultClient,
-				VaultConfig:           vault.DefaultConfig(),
+				VaultConfig:           vaultConfig,
 			},
 			AWSPath: *flagOperatorAWSBackend,
 		})


### PR DESCRIPTION
The config passed to the operator needs to be the same one used to instantiate the client so that the operator can reload the certificate from the environment for the config used by the client, rather than a completely irrelevant, unused, new default config.

```
2020-08-26T08:08:21.117Z    ERROR   controller      Reconciler error {"reconcilerGroup": "", "reconcilerKind": "ServiceAccount", "controller": "serviceaccount", "name": "aws-probe", "namespace": "labs", "error": "Put https://vault:8200/v1/sys/policy/exp-1_aws_labs_aws-probe: x509: certificate signed by unknown authority (possibly because of \"x509: ECDSA verification failure\" while trying to verify candidate authority certificate \"sys-vault CA\")"}
```