### PR TITLE
sidecar: gcp: support gcloud and gsutil

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1049,6 +1049,7 @@ golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914/go.mod h1:gOpvHmFTYa4Iltr
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
+golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d h1:TzXSXBo42m9gQenoE3b9BGiEpg5IG2JkU5FkPIawgtw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/sidecar/provider_gcp.go
+++ b/sidecar/provider_gcp.go
@@ -2,10 +2,13 @@ package sidecar
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
 	"github.com/gorilla/mux"
 	vault "github.com/hashicorp/vault/api"
-	"net/http"
-	"time"
 )
 
 // GCPCredentials are the credentials served by the API
@@ -15,11 +18,27 @@ type GCPCredentials struct {
 	TokenType    string `json:"token_type"`
 }
 
+// metadata is information that is used to masquerade as the GCE metadata server
+type metadata struct {
+	project string
+	email   string
+	scopes  []string
+}
+
+// serviceAccountDetails are returned by calls to computeMetadata/v1/instance/service-accounts/
+type serviceAccountDetails struct {
+	Aliases []string `json:"aliases"`
+	Email   string   `json:"email"`
+	Scopes  []string `json:"scopes"`
+}
+
 // GCPProviderConfig provides methods that allow the sidecar to retrieve and
 // serve GCP credentials from vault for the given configuration
 type GCPProviderConfig struct {
 	GcpPath    string
 	GcpRoleSet string
+
+	metadata *metadata
 }
 
 // credentialsPath returns the path to serve the credentials on
@@ -50,7 +69,17 @@ func (gpc *GCPProviderConfig) credentials(client *vault.Client) (interface{}, ti
 	if err != nil {
 		return nil, -1, err
 	}
-	log.Info("new gcp credentials", "expiration", time.Unix(expiresAtSeconds, 0).Format("2006-01-02 15:04:05"))
+
+	if err := gpc.updateMetadata(client); err != nil {
+		return nil, -1, err
+	}
+
+	log.Info("new gcp credentials",
+		"expiration", time.Unix(expiresAtSeconds, 0).Format("2006-01-02 15:04:05"),
+		"project", gpc.metadata.project,
+		"service_account_email", gpc.metadata.email,
+		"scopes", gpc.metadata.scopes,
+	)
 
 	return &GCPCredentials{
 		AccessToken:  secret.Data["token"].(string),
@@ -70,19 +99,137 @@ func (gpc *GCPProviderConfig) secretPath() string {
 	return gpc.GcpPath + "/token/" + gpc.GcpRoleSet
 }
 
-// setupAdditionalEndpoints adds an additional endpoint required to masuqerade
+// updateMetadata extracts metadata from the roleset in vault
+func (gpc *GCPProviderConfig) updateMetadata(client *vault.Client) error {
+	roleset, err := client.Logical().Read(gpc.GcpPath + "/roleset/" + gpc.GcpRoleSet)
+	if err != nil {
+		return err
+	}
+
+	var scopes []string
+	tokenScopes, ok := roleset.Data["token_scopes"].([]interface{})
+	if !ok {
+		return fmt.Errorf("token_scopes is not a []interface{}")
+	}
+	for _, ts := range tokenScopes {
+		scope, ok := ts.(string)
+		if !ok {
+			return fmt.Errorf("scope is not a string")
+		}
+		scopes = append(scopes, scope)
+	}
+
+	project, ok := roleset.Data["project"].(string)
+	if !ok {
+		return fmt.Errorf("project is not a string")
+	}
+
+	email, ok := roleset.Data["service_account_email"].(string)
+	if !ok {
+		return fmt.Errorf("service_account_email is not a string")
+	}
+
+	gpc.metadata = &metadata{
+		email:   email,
+		project: project,
+		scopes:  scopes,
+	}
+
+	return nil
+}
+
+// setupAdditionalEndpoints adds the additional endpoints required to masquerade
 // as the GCE metdata service
 func (gpc *GCPProviderConfig) setupAdditionalEndpoints(r *mux.Router) {
+	r.HandleFunc("/computeMetadata/v1/project/project-id", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/text")
+		w.Write([]byte(gpc.metadata.project))
+	})
+	r.HandleFunc("/computeMetadata/v1/project/numeric-project-id", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/text")
+		w.Write([]byte(`000000000000`))
+	})
+	r.HandleFunc("/computeMetadata/v1/instance/service-accounts", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://"+r.Host+r.URL.Path+"/", http.StatusMovedPermanently)
+	})
+	r.HandleFunc("/computeMetadata/v1/instance/service-accounts/", func(w http.ResponseWriter, r *http.Request) {
+		if err := r.ParseForm(); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if v := r.Form["recursive"]; len(v) != 1 || v[0] != "true" {
+			w.Header().Set("Content-Type", "application/text")
+			w.Write([]byte("default/\n" + gpc.metadata.email + "/\n"))
+			return
+		}
+		data, err := json.Marshal(map[string]*serviceAccountDetails{
+			"default": &serviceAccountDetails{
+				Aliases: []string{
+					"default",
+				},
+				Email:  gpc.metadata.email,
+				Scopes: gpc.metadata.scopes,
+			},
+			gpc.metadata.email: &serviceAccountDetails{
+				Aliases: []string{
+					"default",
+				},
+				Email:  gpc.metadata.email,
+				Scopes: gpc.metadata.scopes,
+			},
+		})
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			w.Header().Set("Content-Type", "application/text")
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(data)
+	})
 	r.HandleFunc("/computeMetadata/v1/instance/service-accounts/{service_account}/", func(w http.ResponseWriter, r *http.Request) {
 		if err := r.ParseForm(); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		if v := r.Form["recursive"]; len(v) != 1 || v[0] != "true" {
-			w.WriteHeader(http.StatusNotImplemented)
+			w.Header().Set("Content-Type", "application/text")
+			w.Write([]byte("aliases\nemail\nidentity\nscopes\ntoken\n"))
+			return
+		}
+		data, err := json.Marshal(&serviceAccountDetails{
+			Aliases: []string{
+				"default",
+			},
+			Email:  gpc.metadata.email,
+			Scopes: gpc.metadata.scopes,
+		})
+		if err != nil {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			w.Header().Set("Content-Type", "application/text")
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"aliases":["default"],"email":"default","scopes":[]}`))
+		w.Write(data)
+	})
+	r.HandleFunc("/computeMetadata/v1/instance/service-accounts/{service_account}/aliases", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/text")
+		w.Write([]byte(`default`))
+	})
+	r.HandleFunc("/computeMetadata/v1/instance/service-accounts/{service_account}/email", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/text")
+		w.Write([]byte(gpc.metadata.email))
+	})
+	r.HandleFunc("/computeMetadata/v1/instance/service-accounts/{service_account}/scopes", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/text")
+		w.Write([]byte(strings.Join(gpc.metadata.scopes, "\n")))
+	})
+	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Metadata-Flavor", "Google")
+		w.Header().Set("Content-Type", "application/text")
+		w.Write([]byte(`ok`))
 	})
 }


### PR DESCRIPTION
More GCE metadata server paths need to be mocked out for `gcloud`
and `gsutil` to work. The information that is presented by the server is
read from `gcp/roleset/<roleset name>`, so the policy attached to the
Kubernetes auth role in vault will need to allow this.