### PR TITLE
sidecar: remove aws from logging address

### DIFF
--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	log = ctrl.Log.WithName("sidecar").WithName("aws")
+	log = ctrl.Log.WithName("sidecar")
 )
 
 // Config configures the sidecar


### PR DESCRIPTION
This logger is used by the gcp provider as well. The sidecar you are running is obvious from the command you run the sidecar with so there's no real need to indicate it in the logs.