### PR TITLE
sidecar: infer the role names from the jwt token claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,17 +82,13 @@ Supported providers (secret engines):
 For `aws`:
 
 ```
-./vault-kube-cloud-credentials aws-sidecar \
-  -kube-auth-role=<kubernetes auth role> \
-  -aws-role=<aws secret role>
+./vault-kube-cloud-credentials aws-sidecar
 ```
 
 And `gcp`:
 
 ```
-./vault-kube-cloud-credentials gcp-sidecar \
-  -kube-auth-role=<kubernetes auth role> \
-  -gcp-roleset=<gcp secret roleset>
+./vault-kube-cloud-credentials gcp-sidecar
 ```
 
 Refer to the usage for more options:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.66.0 // indirect
 	github.com/Azure/go-autorest/autorest v0.11.6 // indirect
 	github.com/aws/aws-sdk-go v1.34.29
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-logr/logr v0.2.1
 	github.com/go-logr/zapr v0.2.0 // indirect
 	github.com/golang/snappy v0.0.2 // indirect

--- a/manifests/examples/aws-sidecar/aws-probe.yaml
+++ b/manifests/examples/aws-sidecar/aws-probe.yaml
@@ -23,21 +23,11 @@ spec:
           image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.5.1
           args:
             - aws-sidecar
-            - -role=$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)
-            - -kube-auth-role=$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)
           env:
             - name: VAULT_ADDR
               value: "https://vault.example-namespace:8200"
             - name: VAULT_CACERT
               value: "/etc/tls/ca.crt"
-            - name: POD_SERVICE_ACCOUNT
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
           volumeMounts:
             - name: vault-tls
               mountPath: /etc/tls

--- a/manifests/examples/gcp-sidecar/gcp-probe.yaml
+++ b/manifests/examples/gcp-sidecar/gcp-probe.yaml
@@ -23,25 +23,11 @@ spec:
           image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.5.1
           args:
             - gcp-sidecar
-            - -roleset=$(ENVIRONMENT)-$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)
-            - -kube-auth-role=$(ENVIRONMENT)-$(POD_NAMESPACE)-$(POD_SERVICE_ACCOUNT)
           env:
             - name: VAULT_ADDR
               value: "https://vault.example-namespace:8200"
             - name: VAULT_CACERT
               value: "/etc/tls/ca.crt"
-            - name: POD_SERVICE_ACCOUNT
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.serviceAccountName
-            - name: POD_NAMESPACE
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.namespace
-            # This value corresponds to the this variable:
-            # https://github.com/utilitywarehouse/tf_kube_creds_provider_via_vault/blob/master/gcp/variables.tf#L1-L3
-            - name: ENVIRONMENT
-              value: exp-1
           volumeMounts:
             - name: vault-tls
               mountPath: /etc/tls

--- a/token.go
+++ b/token.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+type kubeTokenClaims struct {
+	Namespace          string `json:"kubernetes.io/serviceaccount/namespace"`
+	ServiceAccountName string `json:"kubernetes.io/serviceaccount/service-account.name"`
+}
+
+// Valid implements jwt.Claims. It's never called because we're only running
+// ParseUnverified.
+func (c *kubeTokenClaims) Valid() error {
+	return nil
+}
+
+func newKubeTokenClaimsFromFile(tokenFile string) (*kubeTokenClaims, error) {
+	token, err := ioutil.ReadFile(tokenFile)
+	if err != nil {
+		return nil, err
+	}
+
+	jwtParser := &jwt.Parser{}
+
+	claims := &kubeTokenClaims{}
+	if _, _, err := jwtParser.ParseUnverified(string(token), claims); err != nil {
+		return nil, err
+	}
+
+	if claims.Namespace == "" {
+		return claims, fmt.Errorf("missing claim for kubernetes.io/serviceaccount/namespace")
+	}
+
+	if claims.ServiceAccountName == "" {
+		return claims, fmt.Errorf("missing claim for kubernetes.io/serviceaccount/service-account.name")
+	}
+
+	return claims, nil
+}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewKubeTokenClaimsFromFile(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss":                                    "kubernetes/serviceaccount",
+		"kubernetes.io/serviceaccount/namespace": "foo",
+		"kubernetes.io/serviceaccount/secret.name":          "bar-token-8mjcw",
+		"kubernetes.io/serviceaccount/service-account.name": "bar",
+		"kubernetes.io/serviceaccount/service-account.uid":  "d8f5785e-1477-11eb-adc1-0242ac120002",
+		"sub": "system:serviceaccount:foo:bar",
+	})
+
+	ss, err := token.SignedString([]byte("SuperDuperSecure"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpFile, err := ioutil.TempFile("", "jwt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write([]byte(ss)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	claims, err := newKubeTokenClaimsFromFile(tmpFile.Name())
+	assert.NoError(t, err)
+	assert.Equal(t, "foo", claims.Namespace)
+	assert.Equal(t, "bar", claims.ServiceAccountName)
+}
+
+func TestNewKubeTokenClaimsFromFileInvalidClaims(t *testing.T) {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": "kubernetes/serviceaccount",
+		"kubernetes.io/serviceaccount/secret.name":         "bar-token-8mjcw",
+		"kubernetes.io/serviceaccount/service-account.uid": "d8f5785e-1477-11eb-adc1-0242ac120002",
+		"sub": "system:serviceaccount:foo:bar",
+	})
+
+	ss, err := token.SignedString([]byte("SuperDuperSecure"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tmpFile, err := ioutil.TempFile("", "jwt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+	if _, err := tmpFile.Write([]byte(ss)); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = newKubeTokenClaimsFromFile(tmpFile.Name())
+	assert.Error(t, err)
+}


### PR DESCRIPTION
The sidecar is designed to work in conjunction with the operator which creates predictable names based on the namespace and service account. This name can therefore be inferred from the claims of the jwt token, which simplifies the arguments that need to be passed to the sidecar.