### PR TITLE
sidecar: add prometheus metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gophercloud/gophercloud v0.12.0 // indirect
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-retryablehttp v0.6.7 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2
 	github.com/hashicorp/vault v1.5.0
 	github.com/hashicorp/vault-plugin-auth-kubernetes v0.7.0
 	github.com/hashicorp/vault/api v1.0.5-0.20200630205458-1a16f3c699c6
@@ -22,6 +23,7 @@ require (
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/prometheus/client_golang v1.7.1
 	github.com/prometheus/common v0.13.0 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/utilitywarehouse/go-operational v0.0.0-20190722153447-b0f3f6284543

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	flagAWSKubeBackend   = awsSidecarCommand.String("kube-auth-backend", "kubernetes", "Kubernetes auth backend")
 	flagAWSKubeTokenPath = awsSidecarCommand.String("kube-token-path", "/var/run/secrets/kubernetes.io/serviceaccount/token", "Path to the kubernetes serviceaccount token")
 	flagAWSListenAddr    = awsSidecarCommand.String("listen-address", "127.0.0.1:8000", "Listen address")
+	flagAWSOpsAddr       = awsSidecarCommand.String("operational-address", ":8099", "Listen address for operational status endpoints")
 
 	gcpSidecarCommand    = flag.NewFlagSet("gcp-sidecar", flag.ExitOnError)
 	flagGCPPrefix        = gcpSidecarCommand.String("prefix", "vkcc", "The prefix used by the operator to create the login and backend roles")
@@ -42,6 +43,7 @@ var (
 	flagGCPKubeBackend   = gcpSidecarCommand.String("kube-auth-backend", "kubernetes", "Kubernetes auth backend")
 	flagGCPKubeTokenPath = gcpSidecarCommand.String("kube-token-path", "/var/run/secrets/kubernetes.io/serviceaccount/token", "Path to the kubernetes serviceaccount token")
 	flagGCPListenAddr    = gcpSidecarCommand.String("listen-address", "127.0.0.1:8000", "Listen address")
+	flagGCPOpsAddr       = gcpSidecarCommand.String("operational-address", ":8099", "Listen address for operational status endpoints")
 
 	log = ctrl.Log.WithName("main")
 )
@@ -178,6 +180,7 @@ func main() {
 			KubeAuthPath:  *flagAWSKubeBackend,
 			KubeAuthRole:  kubeAuthRole,
 			ListenAddress: *flagAWSListenAddr,
+			OpsAddress:    *flagAWSOpsAddr,
 			ProviderConfig: &sidecar.AWSProviderConfig{
 				Path:    *flagAWSBackend,
 				RoleArn: *flagAWSRoleArn,
@@ -226,6 +229,7 @@ func main() {
 			KubeAuthPath:  *flagGCPKubeBackend,
 			KubeAuthRole:  kubeAuthRole,
 			ListenAddress: *flagGCPListenAddr,
+			OpsAddress:    *flagGCPOpsAddr,
 			ProviderConfig: &sidecar.GCPProviderConfig{
 				Path:    *flagGCPBackend,
 				RoleSet: gcpRoleSet,

--- a/sidecar/metrics.go
+++ b/sidecar/metrics.go
@@ -1,0 +1,60 @@
+package sidecar
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/utilitywarehouse/go-operational/op"
+)
+
+const (
+	appName        = "vault-kube-cloud-credentials"
+	appDescription = "Fetch cloud provider credentials from vault on behalf of a Kubernetes service account and serve them via HTTP."
+	promNamespace  = "vkcc"
+	promSubsystem  = "sidecar"
+)
+
+var (
+	promExpiry = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName(promNamespace, promSubsystem, "expiry_timestamp_seconds"),
+		Help: "Returns the expiry date for the current credentials, expressed as a Unix Epoch Time",
+	})
+	promRenewals = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(promNamespace, promSubsystem, "renewals_total"),
+		Help: "Total count of renewals",
+	})
+	promErrors = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(promNamespace, promSubsystem, "errors_total"),
+		Help: "Total count of errors",
+	})
+	promVaultRequests = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: prometheus.BuildFQName(promNamespace, promSubsystem, "vault_requests_total"),
+		Help: "Total count of requests to Vault, by code and method",
+	},
+		[]string{"code", "method"},
+	)
+	promVaultRequestsInFlight = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: prometheus.BuildFQName(promNamespace, promSubsystem, "vault_in_flight_requests"),
+		Help: "Number of requests to Vault currently in-flight",
+	})
+	promVaultRequestsDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: prometheus.BuildFQName(promNamespace, promSubsystem, "vault_request_duration_seconds"),
+		Help: "A histogram of request latencies to Vault",
+	},
+		[]string{},
+	)
+	statusHandler = op.NewHandler(
+		op.NewStatus(appName, appDescription).
+			AddOwner("system", "#infra").
+			AddLink("readme", fmt.Sprintf("https://github.com/utilitywarehouse/%s/blob/master/README.md", appName)).
+			AddMetrics(
+				promExpiry,
+				promRenewals,
+				promErrors,
+				promVaultRequests,
+				promVaultRequestsDuration,
+				promVaultRequestsInFlight,
+			).
+			ReadyAlways(),
+	)
+)

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -1,21 +1,19 @@
 package sidecar
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/gorilla/mux"
+	rootcerts "github.com/hashicorp/go-rootcerts"
 	vault "github.com/hashicorp/vault/api"
-	"github.com/utilitywarehouse/go-operational/op"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	ctrl "sigs.k8s.io/controller-runtime"
-)
-
-const (
-	appName        = "vault-kube-cloud-credentials"
-	appDescription = "Fetch cloud provider credentials from vault on behalf of a Kubernetes service account and serve them via HTTP."
 )
 
 var (
@@ -35,14 +33,26 @@ type Config struct {
 // provided ProviderConfig
 type Sidecar struct {
 	*Config
-	backoff     *Backoff
-	vaultClient *vault.Client
-	vaultConfig *vault.Config
+	backoff        *Backoff
+	vaultClient    *vault.Client
+	vaultConfig    *vault.Config
+	vaultTLSConfig *tls.Config
 }
 
 // New returns a sidecar with the provided config
 func New(config *Config) (*Sidecar, error) {
 	vaultConfig := vault.DefaultConfig()
+
+	// Capture the TLS config of the Transport before it's wrapped and
+	// therefore unavailable. This is updated by reloadVaultCA.
+	vaultTLSConfig := vaultConfig.HttpClient.Transport.(*http.Transport).TLSClientConfig
+
+	vaultConfig.HttpClient.Transport = promhttp.InstrumentRoundTripperInFlight(promVaultRequestsInFlight,
+		promhttp.InstrumentRoundTripperCounter(promVaultRequests,
+			promhttp.InstrumentRoundTripperDuration(promVaultRequestsDuration, vaultConfig.HttpClient.Transport),
+		),
+	)
+
 	vaultClient, err := vault.NewClient(vaultConfig)
 	if err != nil {
 		return nil, err
@@ -55,10 +65,11 @@ func New(config *Config) (*Sidecar, error) {
 	}
 
 	return &Sidecar{
-		Config:      config,
-		backoff:     backoff,
-		vaultConfig: vaultConfig,
-		vaultClient: vaultClient,
+		Config:         config,
+		backoff:        backoff,
+		vaultConfig:    vaultConfig,
+		vaultClient:    vaultClient,
+		vaultTLSConfig: vaultTLSConfig,
 	}, nil
 }
 
@@ -73,12 +84,16 @@ func (s *Sidecar) Run() error {
 		for {
 			duration, err := s.renew()
 			if err != nil {
+				promErrors.Inc()
 				d := s.backoff.Duration()
 				log.Error(err, "error renewing credentials", "backoff", d)
 				time.Sleep(d)
 				continue
 			}
 			s.backoff.Reset()
+
+			promRenewals.Inc()
+			promExpiry.Set(float64(time.Now().Add(duration).Unix()))
 
 			// Sleep until its time to renew the creds
 			time.Sleep(sleepDuration(duration))
@@ -95,11 +110,7 @@ func (s *Sidecar) Run() error {
 	r := mux.NewRouter()
 
 	// Add operational endpoints
-	r.Handle("/__/", op.NewHandler(op.NewStatus(appName, appDescription).
-		AddOwner("system", "#infra").
-		AddLink("readme", fmt.Sprintf("https://github.com/utilitywarehouse/%s/blob/master/README.md", appName)).
-		ReadyAlways()),
-	)
+	r.PathPrefix("/__/").Handler(statusHandler)
 
 	// Add provider-specific endpoints
 	s.ProviderConfig.setupEndpoints(r)
@@ -111,8 +122,8 @@ func (s *Sidecar) Run() error {
 
 // renew the credentials
 func (s *Sidecar) renew() (time.Duration, error) {
-	// Reload vault configuration from the environment
-	if err := s.vaultConfig.ReadEnvironment(); err != nil {
+	// Reload vault CA from the environment
+	if err := s.reloadVaultCA(); err != nil {
 		return -1, err
 	}
 
@@ -137,11 +148,40 @@ func (s *Sidecar) renew() (time.Duration, error) {
 	}
 	s.vaultClient.SetToken(secret.Auth.ClientToken)
 
-	// Retrieve credentials for the provider
+	// Renew credentials for the provider
 	return s.ProviderConfig.renew(s.vaultClient)
 }
 
-// Sleep for 1/3 of the lease duration with a random jitter to discourage syncronised API calls from
+// reloadVaultCA updates the tls.Config used by the vault client with the CA
+// cert(s) pointed to by VAULT_CACERT or VAULT_CAPATH. This makes the sidecar
+// tolerant of CA renewals.
+func (s *Sidecar) reloadVaultCA() error {
+	var envCACert string
+	var envCAPath string
+
+	if v := os.Getenv(vault.EnvVaultCACert); v != "" {
+		envCACert = v
+	}
+
+	if v := os.Getenv(vault.EnvVaultCAPath); v != "" {
+		envCAPath = v
+	}
+
+	if envCACert != "" || envCAPath != "" {
+		err := rootcerts.ConfigureTLS(s.vaultTLSConfig, &rootcerts.Config{
+			CAPath: envCAPath,
+			CAFile: envCACert,
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+// Sleep for 1/3 of the lease duration with a random jitter to discourage synchronised API calls from
 // multiple instances of the application
 func sleepDuration(leaseDuration time.Duration) time.Duration {
 	return time.Duration((float64(leaseDuration.Nanoseconds()) * 1 / 3) * (rand.Float64() + 1.50) / 2)


### PR DESCRIPTION
- Instruments the `http.RoundTripper` used by Vault with prometheus metrics that measure the request rate and latency, as well as the number of requests currently in flight. The `vault.Config.ReadEnvironment()` function didn't play well with this because it makes a type assertion of `*http.Transport` when the underlying type has changed to `promhttp.RoundTripperFunc`. It's not a lot of work to handle this ourselves.
- Exports the expiry date of the credential lease as a metric
- Tracks the number of errors and successful renewals from the perspective of the sidecar
- Fixes the operational endpoint, which broke when we introduced gorilla/mux because, unlike http.Handle, mux.Handle only serves on one particular path.