### PR TITLE
sidecar: fix high CPU usage when waiting for provider to become ready

### DIFF
--- a/sidecar/provider.go
+++ b/sidecar/provider.go
@@ -11,7 +11,7 @@ import (
 // ProviderConfig provides generic methods for retrieving and serving
 // credentials from vault for a cloud provider
 type ProviderConfig interface {
-	ready() bool
+	ready() <-chan bool
 	renew(client *vault.Client) (time.Duration, error)
 	setupEndpoints(r *mux.Router)
 }

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -135,6 +135,7 @@ func (s *Sidecar) Run() error {
 			if s.ProviderConfig.ready() {
 				break
 			}
+			time.Sleep(1 * time.Second)
 		}
 		log.Info("webserver is listening", "address", s.ListenAddress)
 		errors <- http.ListenAndServe(s.ListenAddress, ir)

--- a/sidecar/sidecar.go
+++ b/sidecar/sidecar.go
@@ -130,13 +130,9 @@ func (s *Sidecar) Run() error {
 	)
 
 	go func() {
-		// Block until the provider is ready to serve credentials
-		for {
-			if s.ProviderConfig.ready() {
-				break
-			}
-			time.Sleep(1 * time.Second)
-		}
+		// Block until the provider has retrieved the first set of
+		// credentials
+		<-s.ProviderConfig.ready()
 		log.Info("webserver is listening", "address", s.ListenAddress)
 		errors <- http.ListenAndServe(s.ListenAddress, ir)
 	}()


### PR DESCRIPTION
The sidecar was consuming tons of CPU when it couldn't retrieve credentials immediately.