### PR TITLE
sidecar: fix block introduced by non init'd channel

### DIFF
--- a/sidecar/provider.go
+++ b/sidecar/provider.go
@@ -11,7 +11,6 @@ import (
 // ProviderConfig provides generic methods for retrieving and serving
 // credentials from vault for a cloud provider
 type ProviderConfig interface {
-	ready() <-chan bool
 	renew(client *vault.Client) (time.Duration, error)
 	setupEndpoints(r *mux.Router)
 }

--- a/sidecar/provider_gcp.go
+++ b/sidecar/provider_gcp.go
@@ -74,7 +74,6 @@ type GCPProviderConfig struct {
 	Path    string
 	RoleSet string
 
-	r        chan bool
 	creds    *GCPCredentials
 	metadata *gceMetadata
 }
@@ -114,16 +113,10 @@ func (gpc *GCPProviderConfig) renew(client *vault.Client) (time.Duration, error)
 		"scopes", gpc.metadata.scopes,
 	)
 
-	firstRun := gpc.creds == nil
-
 	gpc.creds = &GCPCredentials{
 		AccessToken: secret.Data["token"].(string),
 		TokenType:   "Bearer",
 		expiresAt:   expiresAt,
-	}
-
-	if firstRun {
-		gpc.r <- true
 	}
 
 	return leaseDuration, nil
@@ -166,12 +159,6 @@ func (gpc *GCPProviderConfig) updateMetadata(client *vault.Client) error {
 	}
 
 	return nil
-}
-
-// ready returns a channel that will be written to when the provider first
-// enters a state where it's ready to serve credentials
-func (gpc *GCPProviderConfig) ready() <-chan bool {
-	return gpc.r
 }
 
 // setupEndpoints adds the endpoints required to masquerade


### PR DESCRIPTION
The channel wasn't being created before we were writing/reading from it so it would block forever 🤦 

Fix that and move the ready channel out of the providers and into the main sidecar Run func.