### PR TITLE
operator: configuration from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 
 [![Build Status](https://drone.prod.merit.uw.systems/api/badges/utilitywarehouse/vault-kube-cloud-credentials/status.svg)](https://drone.prod.merit.uw.systems/utilitywarehouse/vault-kube-cloud-credentials)
 
-<!-- vim-markdown-toc GFM -->
-
-* [Operator](#operator)
-  * [Requirements](#requirements)
-  * [Usage](#usage)
-  * [Config file](#config-file)
-    * [Rules](#rules)
-  * [Role names](#role-names)
-* [Sidecars](#sidecars)
-  * [Usage](#usage-1)
-  * [Renewal](#renewal)
-
-<!-- vim-markdown-toc -->
-
 Vault Kube Cloud Credentials (lovingly VKCC - shorthand) - is an application
 that runs in two modes - **operator** and **sidecar**.
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@
 <!-- vim-markdown-toc GFM -->
 
 * [Operator](#operator)
-	* [Requirements](#requirements)
-	* [Usage](#usage)
-	* [Config file](#config-file)
-	* [Role names](#role-names)
+  * [Requirements](#requirements)
+  * [Usage](#usage)
+  * [Config file](#config-file)
+    * [Rules](#rules)
+  * [Role names](#role-names)
 * [Sidecars](#sidecars)
-	* [Usage](#usage-1)
-	* [Renewal](#renewal)
+  * [Usage](#usage-1)
+  * [Renewal](#renewal)
 
 <!-- vim-markdown-toc -->
 
@@ -56,10 +57,7 @@ Annotate your ServiceAccounts and the operator will create the corresponding
 login role and AWS secret role in Vault at
 `auth/kubernetes/roles/<prefix>_aws_<namespace>_<name>` and
 `aws/role/<prefix>_aws_<namespace>_<name>` respectively, where `<prefix>` is the
-string supplied with the `-prefix` flag (default: `vkcc`)
-
-`-prefix` - is used to distinguish between multiple Vault deployments that
-create roles in the same Provider account.
+value of `prefix` in the configuration file (default: `vkcc`).
 
 ```
 apiVersion: v1
@@ -72,8 +70,18 @@ metadata:
 
 ### Config file
 
-You control which ServiceAccounts can assume which roles based on their
-namespace by passing a yaml file to the operator with the flag `-config-file`.
+The operator can be configured by a yaml file passed to the operator with the flag
+`-config-file`.
+
+If no file is provided then the defaults are used. Any omitted values revert to
+their defaults.
+
+Refer to the `defaultFileConfig` in [operator/config.go](operator/config.go).
+
+#### Rules
+
+You can control which service accounts can assume which roles based on their
+namespace by setting rules under `aws.rules`.
 
 For example, the following configuration allows service accounts in `kube-system`
 and namespaces prefixed with `system-` to assume roles under the `sysadmin/*` path,

--- a/manifests/examples/operator/kustomization.yaml
+++ b/manifests/examples/operator/kustomization.yaml
@@ -3,10 +3,14 @@ kind: Kustomization
 bases:
   # github.com/utilitywarehouse/vault-kube-cloud-credentials/manifests/operator/cluster?ref=master
   - ../../operator/cluster
-  # github.com/utilitywarehouse/vault-kube-cloud-credentials/manifests/operator/cluster?ref=master
+  # github.com/utilitywarehouse/vault-kube-cloud-credentials/manifests/operator/namespaced?ref=master
   - ../../operator/namespaced
 resources:
   - rbac.yaml
+configMapGenerator:
+  - name: vault-kube-cloud-credentials-operator
+    files:
+      - config.yaml=resources/operator-config.yaml
 secretGenerator:
   - name: vault
     envs:

--- a/manifests/examples/operator/resources/operator-config.yaml
+++ b/manifests/examples/operator/resources/operator-config.yaml
@@ -1,0 +1,13 @@
+prefix: "dev"
+aws:
+  rules:
+    - namespacePatterns:
+        - kube-system
+        - system-*
+      roleNamePatterns:
+        - sysadmin-*
+        - sysadmin/*
+        - org/s3-admin
+      accountIDs:
+        - 000000000000
+        - 111111111111

--- a/manifests/examples/operator/vault-kube-cloud-credentials-operator-patch.yaml
+++ b/manifests/examples/operator/vault-kube-cloud-credentials-operator-patch.yaml
@@ -7,6 +7,9 @@ spec:
     spec:
       containers:
         - name: vault-kube-cloud-credentials-operator
+          args:
+            - operator
+            - -config-file=/etc/vkcc/config.yaml
           env:
             - name: VAULT_ADDR
               value: "https://vault:8200"
@@ -18,9 +21,14 @@ spec:
                   name: vault
                   key: root-token
           volumeMounts:
+            - name: config
+              mountPath: /etc/vkcc
             - name: tls
               mountPath: /etc/tls
       volumes:
+        - name: config
+          configMap:
+            name: vault-kube-cloud-credentials-operator
         - name: tls
           secret:
             secretName: vault-tls

--- a/manifests/operator/namespaced/vault-kube-cloud-credentials-operator.yaml
+++ b/manifests/operator/namespaced/vault-kube-cloud-credentials-operator.yaml
@@ -21,6 +21,8 @@ spec:
       containers:
         - name: vault-kube-cloud-credentials-operator
           image: quay.io/utilitywarehouse/vault-kube-cloud-credentials:0.8.1
+          args:
+            - operator
           resources:
             requests:
               cpu: 10m

--- a/operator/aws_test.go
+++ b/operator/aws_test.go
@@ -54,8 +54,8 @@ func TestAWSOperatorReconcile(t *testing.T) {
 			VaultClient:           core.Client,
 			VaultConfig:           vaultapi.DefaultConfig(),
 		},
-		AWSPath:    "aws",
 		DefaultTTL: 3600 * time.Second,
+		AWSPath:    "aws",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -276,20 +276,19 @@ func TestOperatorReconcileBlocked(t *testing.T) {
 			VaultConfig:           vaultapi.DefaultConfig(),
 		},
 		AWSPath: "aws",
+		Rules: AWSRules{
+			AWSRule{
+				NamespacePatterns: []string{
+					"notbar",
+				},
+				RoleNamePatterns: []string{
+					"not-foobar-role",
+				},
+			},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	a.rules = AWSRules{
-		AWSRule{
-			NamespacePatterns: []string{
-				"notbar",
-			},
-			RoleNamePatterns: []string{
-				"not-foobar-role",
-			},
-		},
 	}
 
 	// This shouldn't create the objects in vault
@@ -458,7 +457,8 @@ func TestAWSOperatorAdmitEvent(t *testing.T) {
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 
 	o := &AWSOperator{
-		log: ctrl.Log.WithName("operator").WithName("aws"),
+		AWSOperatorConfig: &AWSOperatorConfig{},
+		log:               ctrl.Log.WithName("operator").WithName("aws"),
 	}
 
 	// Test that without any rules any valid event is admitted
@@ -474,7 +474,7 @@ func TestAWSOperatorAdmitEvent(t *testing.T) {
 	// iam)
 	assert.False(t, o.admitEvent("foobar", "arn:aws:iam:111111111111:role/foobar-role"))
 
-	o.rules = AWSRules{
+	o.Rules = AWSRules{
 		AWSRule{
 			NamespacePatterns: []string{
 				"foo",

--- a/operator/config.go
+++ b/operator/config.go
@@ -1,0 +1,69 @@
+package operator
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	defaultFileConfig = &fileConfig{
+		KubernetesAuthBackend: "kubernetes",
+		MetricsAddress:        ":8080",
+		Prefix:                "vkcc",
+		AWS: awsFileConfig{
+			DefaultTTL: 15 * time.Minute,
+			Path:       "aws",
+		},
+	}
+)
+
+type fileConfig struct {
+	// KubernetesAuthBackend is the mount path of the kubernetes auth
+	// backend
+	KubernetesAuthBackend string `yaml:"kubernetesAuthBackend"`
+	// MetricsAddress is the address metrics are served on
+	MetricsAddress string `yaml:"metricsAddress"`
+	// Prefix is appended to objects created in Vault by the operator
+	Prefix string `yaml:"prefix"`
+	// AWS is configuration for the AWS secret backend
+	AWS awsFileConfig `yaml:"aws"`
+}
+
+type awsFileConfig struct {
+	// DefaultTTL is the ttl of credentials that are issued for a role
+	DefaultTTL time.Duration `yaml:"defaultTTL"`
+	// Path is the mount path of the AWS secret backend
+	Path string `yaml:"path"`
+	// Rules that govern which service accounts can assume which roles
+	Rules AWSRules `yaml:"rules"`
+}
+
+func loadConfigFromFile(file string) (*fileConfig, error) {
+	cfg := defaultFileConfig
+
+	if file == "" {
+		return cfg, nil
+	}
+
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		return nil, err
+	}
+
+	if strings.Contains(cfg.Prefix, "_") {
+		return nil, fmt.Errorf("prefix must not contain a '_': %s", cfg.Prefix)
+	}
+
+	if cfg.AWS.Path == "" {
+		return nil, fmt.Errorf("aws.path can't be empty")
+	}
+
+	return cfg, nil
+}


### PR DESCRIPTION
- Pull all operator configuration from a file, rather than a combination of file and flags.
- To enable this, create a central `Operator` struct with a `New` method that reads the config file and configures the required clients.