### PR TITLE
Inject AWS init container before other init containers

### DIFF
--- a/manifests/sidecar-injector/base/vault-init-container-aws-base.yaml
+++ b/manifests/sidecar-injector/base/vault-init-container-aws-base.yaml
@@ -1,4 +1,5 @@
 name: vault-init-container-aws-base
+prependInitContainers: true
 initContainers:
   - name: vault-credentials
     image: vault:1.6.0


### PR DESCRIPTION
Allows other init container steps to use the AWS credentials provisioned by the injected container