### PR TITLE
upx the binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ WORKDIR /go/src/github.com/utilitywarehouse/vault-kube-cloud-credentials
 COPY . /go/src/github.com/utilitywarehouse/vault-kube-cloud-credentials
 
 ENV CGO_ENABLED 0
-RUN apk --no-cache add git \
+RUN apk --no-cache add git upx \
   && go get -t ./... \
   && go test ./... \
-  && go build -o /vault-kube-cloud-credentials .
+  && go build -o /vault-kube-cloud-credentials . \
+  && upx /vault-kube-cloud-credentials
 
 FROM alpine:3.14
 COPY --from=build /vault-kube-cloud-credentials /vault-kube-cloud-credentials


### PR DESCRIPTION
We run the agent as sidecar in a lot of places, so size really matters.
Pack the binary so the image is smaller
