### PR TITLE
Use 1000 user and group id

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ COPY --from=build /vault-kube-cloud-credentials /vault-kube-cloud-credentials
 # ref: https://github.com/kubernetes/git-sync/blob/master/Dockerfile.in#L68
 #
 # By default we will run as this user...
-RUN echo "default:x:65533:65533::/tmp:/sbin/nologin" >> /etc/passwd
+RUN echo "default:x:1000:1000::/tmp:/sbin/nologin" >> /etc/passwd
 # ...but the user might choose a different UID and pass --add-user
 # which needs to be able to write to /etc/passwd.
 RUN chmod 0666 /etc/passwd
 # Add the default GID to /etc/group for completeness.
-RUN echo "default:x:65533:default" >> /etc/group
+RUN echo "default:x:1000:default" >> /etc/group
 # Run as non-root by default.  There's simply no reason to run as root.
-USER 65533:65533
+USER 1000:1000
 
 ENTRYPOINT [ "/vault-kube-cloud-credentials" ]


### PR DESCRIPTION
Does not clash with anything in Alpine, unlike 65533 - which is gid
"nobody" group.
