### PR TITLE
Specify sidecar resource requests and limits

### DIFF
--- a/manifests/sidecar-injector/base/vault-sidecar-aws-base.yaml
+++ b/manifests/sidecar-injector/base/vault-sidecar-aws-base.yaml
@@ -33,11 +33,11 @@ containers:
         protocol: TCP
     resources:
       requests:
-        cpu: 10m
+        cpu: 0m
         memory: 25Mi
       limits:
-        cpu: 100m
-        memory: 50Mi
+        cpu: 1000m
+        memory: 100Mi
     volumeMounts:
       - name: vault-tls
         mountPath: /etc/tls

--- a/manifests/sidecar-injector/base/vault-sidecar-aws-base.yaml
+++ b/manifests/sidecar-injector/base/vault-sidecar-aws-base.yaml
@@ -31,6 +31,13 @@ containers:
       - name: metrics
         containerPort: 8099
         protocol: TCP
+    resources:
+      requests:
+        cpu: 10m
+        memory: 25Mi
+      limits:
+        cpu: 100m
+        memory: 50Mi
     volumeMounts:
       - name: vault-tls
         mountPath: /etc/tls

--- a/manifests/sidecar-injector/base/vault-sidecar-aws-gcp-base.yaml
+++ b/manifests/sidecar-injector/base/vault-sidecar-aws-gcp-base.yaml
@@ -31,6 +31,13 @@ containers:
       - name: metrics
         containerPort: 8099
         protocol: TCP
+    resources:
+      requests:
+        cpu: 0m
+        memory: 25Mi
+      limits:
+        cpu: 1000m
+        memory: 100Mi
     volumeMounts:
       - name: vault-tls
         mountPath: /etc/tls
@@ -66,6 +73,13 @@ containers:
       - name: metrics
         containerPort: 8199
         protocol: TCP
+    resources:
+      requests:
+        cpu: 0m
+        memory: 25Mi
+      limits:
+        cpu: 1000m
+        memory: 100Mi
     volumeMounts:
       - name: vault-tls
         mountPath: /etc/tls

--- a/manifests/sidecar-injector/base/vault-sidecar-gcp-base.yaml
+++ b/manifests/sidecar-injector/base/vault-sidecar-gcp-base.yaml
@@ -33,11 +33,11 @@ containers:
         protocol: TCP
     resources:
       requests:
-        cpu: 10m
+        cpu: 0m
         memory: 25Mi
       limits:
-        cpu: 100m
-        memory: 50Mi
+        cpu: 1000m
+        memory: 100Mi
     volumeMounts:
       - name: vault-tls
         mountPath: /etc/tls

--- a/manifests/sidecar-injector/base/vault-sidecar-gcp-base.yaml
+++ b/manifests/sidecar-injector/base/vault-sidecar-gcp-base.yaml
@@ -31,6 +31,13 @@ containers:
       - name: metrics
         containerPort: 8099
         protocol: TCP
+    resources:
+      requests:
+        cpu: 10m
+        memory: 25Mi
+      limits:
+        cpu: 100m
+        memory: 50Mi
     volumeMounts:
       - name: vault-tls
         mountPath: /etc/tls


### PR DESCRIPTION
I suspect the lack of this messes with our HPAs. From the [docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#how-does-a-horizontalpodautoscaler-work):
> Please note that if some of the Pod's containers do not have the relevant resource request set, CPU utilization for the Pod will not be defined and the autoscaler will not take any action for that metric

IAM HPAs (i.e. `auth/hpa/iam-identity-api`, `auth/hpa/iam-policy-decision-api`) targeting multi-container pods are failing with: `failed to get memory utilization: missing request for memory`. HPAs of single-container pods are OK.
```
$ kubectl --context prod-aws --namespace auth get events | rg horizontal
```

Note:
* Values were roughly taken from the operator
* Probably lot less would suffice, but didn't find an appropriate dashboard in grafana, and haven't investigated it further. Happy to adjust it.
* <img width="1707" alt="Screenshot 2023-03-13 at 17 29 57" src="https://user-images.githubusercontent.com/3509242/224749201-91bae3ad-b19b-4429-89dc-39db06c10543.png">

